### PR TITLE
feat: support line breaks in user title

### DIFF
--- a/templates/macros.html
+++ b/templates/macros.html
@@ -27,7 +27,7 @@
   <div class="header">
       <h1>
         <span class="site-title">{{ config.extra.username }}</span>
-        <span class="site-description">{{ config.extra.user_title }}</span>
+        <span class="site-description">{{ config.extra.user_title | linebreaksbr | safe }}</span>
       </h1>
       <div class="header-icons">
         <a aria-label="Send email" href="#"><i class="icon fa fa-envelope"></i></a>


### PR DESCRIPTION
The user_title I'm using is rather long, it's cleaner to display it on several lines.
Some people might need that as well.