### PR TITLE
Fix For New Zola Versions

### DIFF
--- a/theme.toml
+++ b/theme.toml
@@ -1,7 +1,7 @@
 name = "particle"
 description = "Particle theme for Zola"
 license = "MIT"
-homepage = "https://github.com/svavs/particle"
+homepage = "https://github.com/svavs/particle-zola"
 min_version = "0.11.0"
 demo = "https://particle-zola.vercel.app/"
 

--- a/theme.toml
+++ b/theme.toml
@@ -2,7 +2,7 @@ name = "particle"
 description = "Particle theme for Zola"
 license = "MIT"
 homepage = "https://github.com/svavs/particle-zola"
-min_version = "0.11.0"
+min_version = "0.16.1"
 demo = "https://particle-zola.vercel.app/"
 
 [author]

--- a/vercel.json
+++ b/vercel.json
@@ -1,7 +1,7 @@
 {
   "build": {
     "env": {
-      "ZOLA_VERSION": "0.11.0"
+      "ZOLA_VERSION": "0.16.1"
     }
   }
 }


### PR DESCRIPTION
Zola will no longer `zola serve` or `zola build` unless the content folder exists.

I also updated the theme.toml file homepage to point to the current repository url.