### PR TITLE
Update getzola website in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Theme features:
 
 ## Basic Setup
 
-1. [Install Zola](https://getzola.com)
+1. [Install Zola](https://getzola.org)
 2. Clone the particle theme: `git clone https://github.com/svavs/particle-zola.git`
 3. Edit `config.toml` to personalize your site.
 


### PR DESCRIPTION
It appears that getzola.com is no longer viable. getzola.org seems to be the new address.